### PR TITLE
Gave renderFlags a more appropriate name.

### DIFF
--- a/src/lib/m2/skin.js
+++ b/src/lib/m2/skin.js
@@ -25,7 +25,7 @@ const TextureUnit = new r.Struct({
   submeshIndex: r.uint16le,
   submeshIndex2: r.uint16le,
   colorIndex: r.int16le,
-  renderFlags: r.uint16le,
+  renderFlagsIndex: r.uint16le,
   textureUnitNumber: r.uint16le,
   opCount: r.uint16le,
   textureIndex: r.uint16le,

--- a/src/spec/m2/skin-spec.js
+++ b/src/spec/m2/skin-spec.js
@@ -99,7 +99,7 @@ describe('Skin', function() {
           submeshIndex: 0,
           submeshIndex2: 0,
           colorIndex: -1,
-          renderFlags: 0,
+          renderFlagsIndex: 0,
           textureUnitNumber: 0,
           opCount: 1,
           textureIndex: 0,


### PR DESCRIPTION
I believe renderFlags within a skin file actually points to an index in the M2's renderFlags array.