### PR TITLE
Added support for parsing vertex color details

### DIFF
--- a/src/lib/wmo/group.js
+++ b/src/lib/wmo/group.js
@@ -44,6 +44,15 @@ const MOTV = Chunk({
   textureCoords: new r.Array(float2, 'size', 'bytes')
 });
 
+const MOCV = Chunk({
+  colors: new r.Array(new r.Struct({
+    b: r.uint8,
+    g: r.uint8,
+    r: r.uint8,
+    a: r.uint8
+  }), 'size', 'bytes')
+});
+
 const MOBA = Chunk({
   batches: new r.Array(new r.Struct({
     skips: new r.Reserved(r.int16le, 2 * 3),
@@ -69,19 +78,23 @@ export default Chunked({
     return this.MOGP.flags;
   },
 
+  MOLR: new r.Optional(SkipChunk, function() {
+    return this.flags & 0x200;
+  }),
+  MODR: new r.Optional(SkipChunk, function() {
+    return this.flags & 0x800;
+  }),
   MOBN: new r.Optional(SkipChunk, function() {
     return this.flags & 0x1;
   }),
   MOBR: new r.Optional(SkipChunk, function() {
     return this.flags & 0x1;
   }),
-  MOCV: new r.Optional(SkipChunk, function() {
+  MOCV: new r.Optional(MOCV, function() {
     return this.flags & 0x4;
   }),
-  MOLR: new r.Optional(SkipChunk, function() {
-    return this.flags & 0x200;
-  }),
-  MODR: new r.Optional(SkipChunk, function() {
-    return this.flags & 0x800;
-  })
+
+  indoor: function() {
+    return (this.flags & 0x2000) !== 0 && (this.flags & 0x8) === 0;
+  }
 });

--- a/src/lib/wmo/index.js
+++ b/src/lib/wmo/index.js
@@ -14,11 +14,20 @@ const MOHD = Chunk({
   modelCount: r.uint32le,
   doodadCount: r.uint32le,
   doodadSetCount: r.uint32le,
-  color: r.uint32le,
+  baseColor: new r.Struct({
+    r: r.uint8,
+    g: r.uint8,
+    b: r.uint8,
+    a: r.uint8
+  }),
   wmoID: r.uint32le,
   minBoundingBox: Vec3Float,
   maxBoundingBox: Vec3Float,
-  flags: r.uint32le
+  flags: r.uint32le,
+
+  skipBaseColor: function() {
+    return (this.flags & 0x02) !== 0;
+  }
 });
 
 const MOTX = Chunk({


### PR DESCRIPTION
* Optional chunk ordering in wmo/group.js is now correct.
* MOCV in wmo/group.js is now parsed.
* color in wmo/index.js is now named baseColor for clarity.
* baseColor in wmo/index.js is now parsed into constituent parts (rgba).
* Added indoor flag helper to wmo/group.js.
* Added skipBaseColor flag helper to wmo/index.js.