### PR TITLE
feat: add death-thud-lookups dbc entity

### DIFF
--- a/src/lib/dbc/entities/death-thud-lookups.js
+++ b/src/lib/dbc/entities/death-thud-lookups.js
@@ -1,0 +1,11 @@
+import r from 'restructure';
+
+import Entity from '../entity';
+
+export default Entity({
+  id: r.int32le,
+  sizeClass: r.int32le,
+  terraintypeSoundId: r.int32le,
+  soundEntryId: r.int32le,
+  soundEntryIdWater: r.int32le,
+});

--- a/src/lib/dbc/entities/index.js
+++ b/src/lib/dbc/entities/index.js
@@ -40,6 +40,7 @@ export CreatureType from './creature-type';
 export CurrencyCategory from './currency-category';
 export CurrencyTypes from './currency-types';
 export DanceMoves from './dance-moves';
+export DeathThudLookups from './death-thud-lookups'
 export DeclinedWord from './declined-word';
 export DeclinedWordCases from './declined-word-cases';
 export DungeonEncounter from './dungeon-encounter';


### PR DESCRIPTION
related ot https://github.com/wowserhq/blizzardry/issues/32
schema based on https://github.com/WowDevTools/WDBXEditor/blob/master/WDBXEditor/Definitions/WotLK%203.3.5%20(12340).xml

I tried also to add CharHairTexture.dbc but it has two "boolean value" and I don't know exactly the type and it is not uint32le