### PR TITLE
chore: replace var with const, add minor things

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,24 +30,24 @@ Map tiles containing terrain and object information.
 A map tile consists of 16 by 16 map chunks.
 
 ```javascript
-var r = require('blizzardry/lib/restructure');
-var ADT = require('blizzardry/lib/adt');
+const r = require("blizzardry/lib/restructure");
+const ADT = require("blizzardry/lib/adt");
 
-var io = fs.readFileSync('Azeroth_31_39.adt');
-var stream = new r.DecodeStream(io);
+const io = fs.readFileSync("Azeroth_31_39.adt");
+const stream = new r.DecodeStream(io);
 
-var adt = ADT.decode(stream);
-adt.version // 18
-adt.flags   // 0
+const adt = ADT.decode(stream);
+adt.version; // 18
+adt.flags; // 0
 
-adt.MTEX.filenames // ['Tileset\\Wetlands\\Wetlandsdirt01.blp', ...]
-adt.MMDX.filenames // ['WORLD\\AZEROTH\\ELWYNN\\PASS...\\ELWYNNBUSH09.M2', ...]
+adt.MTEX.filenames; // ['Tileset\\Wetlands\\Wetlandsdirt01.blp', ...]
+adt.MMDX.filenames; // ['WORLD\\AZEROTH\\ELWYNN\\PASS...\\ELWYNNBUSH09.M2', ...]
 
-adt.MCNKs.forEach(function(chunk) {
-  chunk.areaID   // 2365
-  chunk.position // { x: -3733.33, y: 533.33, z: -462.37 }
-  chunk.indexX   // 0
-  chunk.indexY   // 0
+adt.MCNKs.forEach(function (chunk) {
+  chunk.areaID; // 2365
+  chunk.position; // { x: -3733.33, y: 533.33, z: -462.37 }
+  chunk.indexX; // 0
+  chunk.indexY; // 0
 });
 ```
 
@@ -95,27 +95,27 @@ sudo ldconfig
 Compile from source and ensure the library ends up on the load path.
 
 ```javascript
-var BLP = require('blizzardry/lib/blp');
+const BLP = require("blizzardry/lib/blp");
 
-BLP.open('RabbitSkin.blp', function(blp) {
-  blp.version     // 2
-  blp.mipmapCount // 8
+BLP.open("RabbitSkin.blp", function (blp) {
+  blp.version; // 2
+  blp.mipmapCount; // 8
 
-  blp.largest.width  // 128
-  blp.largest.height // 128
-  blp.largest.data   // <Buffer a2 a2 a2 dd a2 ...>
+  blp.largest.width; // 128
+  blp.largest.height; // 128
+  blp.largest.data; // <Buffer a2 a2 a2 dd a2 ...>
 
-  blp.smallest.width  // 1
-  blp.smallest.height // 1
-  blp.smallest.data   // <Buffer 7e 98 af ee>
+  blp.smallest.width; // 1
+  blp.smallest.height; // 1
+  blp.smallest.data; // <Buffer 7e 98 af ee>
 
   // Or directly:
-  blp.mipmaps[3].width  // 16
-  blp.mipmaps[3].height // 16
+  blp.mipmaps[3].width; // 16
+  blp.mipmaps[3].height; // 16
 });
 
 // Or alternatively:
-var blp = BLP.open('RabbitSkin.blp');
+const blp = BLP.open("RabbitSkin.blp");
 // ...
 blp.close();
 ```
@@ -133,30 +133,35 @@ Support to be added [soon™].
 Client database format, containing data on items, NPCs, environments and more.
 
 ```javascript
-var r = require('blizzardry/lib/restructure');
-var DBC = require('blizzardry/lib/dbc');
+const r = require("blizzardry/lib/restructure");
+const DBC = require("blizzardry/lib/dbc");
 
-var io = fs.readFileSync('Faction.dbc');
-var stream = new r.DecodeStream(io);
+const io = fs.readFileSync("Faction.dbc");
+const stream = new r.DecodeStream(io);
 
-var dbc = DBC.decode(stream);
-dbc.signature   // 'WDBC'
-dbc.recordCount // 396
-dbc.records[0]  // <Buffer 01 00 00 00 ff ff ff ff ...>
+const dbc = DBC.decode(stream);
+dbc.signature; // 'WDBC'
+dbc.recordCount; // 396
+dbc.records[0]; // <Buffer 01 00 00 00 ff ff ff ff ...>
 ```
 
 Use [pre-defined DBC entities](src/lib/dbc/entities) for convenience:
 
 ```javascript
-var Faction = require('blizzardry/lib/dbc/entities/faction');
+const r = require("blizzardry/lib/restructure");
+const Faction = require("blizzardry/lib/dbc/entities/faction");
 
-var dbc = Faction.dbc.decode(stream);
-dbc.records.forEach(function(record) {
-  record.id          // 576
-  record.parentID    // 1118
-  record.name        // 'Timbermaw Hold'
-  record.description // 'As the last uncorrupted furbolg tribe ...'
-});
+const io = fs.readFileSync("Faction.dbc");
+const stream = new r.DecodeStream(io);
+
+const dbc = Faction.dbc.decode(stream);
+
+for (const record of dbc.records) {
+  record.id; // 576
+  record.parentID; // 1118
+  record.name; // 'Timbermaw Hold'
+  record.description; // 'As the last uncorrupted furbolg tribe ...'
+}
 ```
 
 ### [M2](src/lib/m2)
@@ -164,16 +169,16 @@ dbc.records.forEach(function(record) {
 3D model format for player characters, NPCs and doodads, among others.
 
 ```javascript
-var r = require('blizzardry/lib/restructure');
-var M2 = require('blizzardry/lib/m2');
+const r = require("blizzardry/lib/restructure");
+const M2 = require("blizzardry/lib/m2");
 
-var io = fs.readFileSync('Rabbit.m2');
-var stream = new r.DecodeStream(io);
+const io = fs.readFileSync("Rabbit.m2");
+const stream = new r.DecodeStream(io);
 
-var m2 = M2.decode(stream);
-m2.signature // 'MD20'
-m2.name      // 'Rabbit'
-m2.vertices[0].position // [ -0.2735.., -0.0035.., 0.3579.. ]
+const m2 = M2.decode(stream);
+m2.signature; // 'MD20'
+m2.name; // 'Rabbit'
+m2.vertices[0].position; // [ -0.2735.., -0.0035.., 0.3579.. ]
 ```
 
 ### [MPQ](src/lib/mpq)
@@ -215,33 +220,33 @@ sudo ldconfig
 Compile from source and ensure the library ends up on the load path.
 
 ```javascript
-var MPQ = require('blizzardry/lib/mpq');
+const MPQ = require("blizzardry/lib/mpq");
 
-MPQ.open('common.MPQ', function(mpq) {
-  mpq.files.contains('Creature\\Illidan\\Illidan.m2') // true
+MPQ.open("common.MPQ", function (mpq) {
+  mpq.files.contains("Creature\\Illidan\\Illidan.m2"); // true
 
   // Extract to local filesystem
-  mpq.files.extract('Creature\\Illidan\\Illidan.m2', '~/Illidan.m2');
+  mpq.files.extract("Creature\\Illidan\\Illidan.m2", "~/Illidan.m2");
 
   // Iterate over all entries
-  mpq.files.all.forEach(function(result) {
-    result.filename // 'SPELLS\\ArcaneBomb_Missle.M2'
-    result.name     // 'ArcaneBomb_Missle.M2'
-    result.filesize // 28928
+  mpq.files.all.forEach(function (result) {
+    result.filename; // 'SPELLS\\ArcaneBomb_Missle.M2'
+    result.name; // 'ArcaneBomb_Missle.M2'
+    result.filesize; // 28928
   });
 
   // Search for entries (supports wildcards)
-  mpq.files.find('*Illidan*');
+  mpq.files.find("*Illidan*");
 
   // Accessing file data
-  var file = mpq.files.get('Creature\\Illidan\\Illidan.m2');
-  file.name // 'Creature\\Illidan\\Illidan.m2'
-  file.size // 1888368
-  file.data // <Buffer 4d 44 32 30 08 01 00 00 ...>
+  const file = mpq.files.get("Creature\\Illidan\\Illidan.m2");
+  file.name; // 'Creature\\Illidan\\Illidan.m2'
+  file.size; // 1888368
+  file.data; // <Buffer 4d 44 32 30 08 01 00 00 ...>
 });
 
 // Or alternatively:
-var mpq = MPQ.open('common.MPQ');
+const mpq = MPQ.open("common.MPQ");
 // ...
 mpq.close();
 ```
@@ -253,17 +258,17 @@ World definition file specifying which map tiles are present.
 A map consists of 64 by 64 [map tiles](#adt).
 
 ```javascript
-var r = require('blizzardry/lib/restructure');
-var WDT = require('blizzardry/lib/wdt');
+const r = require("blizzardry/lib/restructure");
+const WDT = require("blizzardry/lib/wdt");
 
-var io = fs.readFileSync('Azeroth.wdt');
-var stream = new r.DecodeStream(io);
+const io = fs.readFileSync("Azeroth.wdt");
+const stream = new r.DecodeStream(io);
 
-var wdt = WDT.decode(stream);
-wdt.version // 18
-wdt.flags   // 0
-wdt.tiles[30 * 64 + 24] // 0
-wdt.tiles[30 * 64 + 25] // 1
+const wdt = WDT.decode(stream);
+wdt.version; // 18
+wdt.flags; // 0
+wdt.tiles[30 * 64 + 24]; // 0
+wdt.tiles[30 * 64 + 25]; // 1
 ```
 
 ### [WMO](src/lib/wmo)
@@ -273,18 +278,18 @@ Root world map definition file listing textures, doodads and orientation.
 Actual model data is stored in [group files](#wmo-group).
 
 ```javascript
-var r = require('blizzardry/lib/restructure');
-var WMO = require('blizzardry/lib/wmo');
+const r = require("blizzardry/lib/restructure");
+const WMO = require("blizzardry/lib/wmo");
 
-var io = fs.readFileSync('trolltent.wmo');
-var stream = new r.DecodeStream(io);
+const io = fs.readFileSync("trolltent.wmo");
+const stream = new r.DecodeStream(io);
 
-var wmo = WMO.decode(stream);
-wmo.version    // 17
-wmo.flags      // 1
-wmo.groupCount // 1
+const wmo = WMO.decode(stream);
+wmo.version; // 17
+wmo.flags; // 1
+wmo.groupCount; // 1
 
-wmo.MOTX.filenames // ['DUNGEONS\\TEXTURES\\ROOF\\BM_TROLL_KOTOSKIN01.BLP', ...]
+wmo.MOTX.filenames; // ['DUNGEONS\\TEXTURES\\ROOF\\BM_TROLL_KOTOSKIN01.BLP', ...]
 ```
 
 #### [WMO Group](src/lib/wmo/group.js)
@@ -295,16 +300,16 @@ For a root file named `trolltent.wmo`, its group files are named `trolltent_000.
 The amount of groups is exposed as `groupCount` in the root file (see above).
 
 ```javascript
-var r = require('blizzardry/lib/restructure');
-var WMOGroup = require('blizzardry/lib/wmo/group');
+const r = require("blizzardry/lib/restructure");
+const WMOGroup = require("blizzardry/lib/wmo/group");
 
-var io = fs.readFileSync('trolltent_000.wmo');
-var stream = new r.DecodeStream(io);
+const io = fs.readFileSync("trolltent_000.wmo");
+const stream = new r.DecodeStream(io);
 
-var group = WMOGroup.decode(stream);
-group.version // 17
-group.flags   // 1
-group.MOVT.vertices[0] // [ 3.1721.., 10.4109.., 5.7666.. ]
+const group = WMOGroup.decode(stream);
+group.version; // 17
+group.flags; // 1
+group.MOVT.vertices[0]; // [ 3.1721.., 10.4109.., 5.7666.. ]
 ```
 
 ## Development & Contribution
@@ -333,26 +338,28 @@ Getting this toolchain up and running, is easy and straight-forward:
 5. Run `npm run gulp` which will automatically build and test the project when
    source files change.
 
+6. To test your new build you can create a new project folder with inside a `test.js` file with one of the code examples above and with a directory `node_modules/blizzardry/lib`, where `lib` is the build directory output (common called `dist`) inside your `blizzardry` source directory.
+
 When contributing, please:
 
 - Fork the repository
 - Accompany each logical unit of operation with at least one test
 - Open a pull request
 
-[Babel]: https://babeljs.io/
-[Blizzard]: http://blizzard.com
-[BLPConverter]: https://github.com/Kanma/BLPConverter
-[CascLib]: https://github.com/ladislav-zezula/CascLib
-[CMake]: http://www.cmake.org
-[ES2015]: https://babeljs.io/docs/learn-es2015/
-[Gulp]: http://gulpjs.com/
-[Homebrew]: http://brew.sh/
-[Mocha]: http://mochajs.org/
-[Node.js]: http://nodejs.org/#download
-[StormLib]: https://github.com/ladislav-zezula/StormLib
-[Wrath of the Lich King]: http://us.blizzard.com/en-us/games/wrath/
+[babel]: https://babeljs.io/
+[blizzard]: http://blizzard.com
+[blpconverter]: https://github.com/Kanma/BLPConverter
+[casclib]: https://github.com/ladislav-zezula/CascLib
+[cmake]: http://www.cmake.org
+[es2015]: https://babeljs.io/docs/learn-es2015/
+[gulp]: http://gulpjs.com/
+[homebrew]: http://brew.sh/
+[mocha]: http://mochajs.org/
+[node.js]: http://nodejs.org/#download
+[stormlib]: https://github.com/ladislav-zezula/StormLib
+[wrath of the lich king]: http://us.blizzard.com/en-us/games/wrath/
 [mipmaps]: https://en.wikipedia.org/wiki/Mipmap
 [npm]: https://www.npmjs.com/
-[most Blizzard games]: http://en.wikipedia.org/wiki/MPQ#Usage_in_gaming
-[recent Blizzard games]: http://en.wikipedia.org/wiki/MPQ#Replacement:_CASC
+[most blizzard games]: http://en.wikipedia.org/wiki/MPQ#Usage_in_gaming
+[recent blizzard games]: http://en.wikipedia.org/wiki/MPQ#Replacement:_CASC
 [soon™]: http://www.wowwiki.com/Soon


### PR DESCRIPTION
There is no reason to use `var` anymore, so do not use it, never.

I replaced also a `forEach` with `for-of` for performance reasons but also because it is easier to manage and read.

I added a `6.` step into the development step because I was not really familiar with `import/require modules` logic in nodejs. 